### PR TITLE
Fix pre-2005 events

### DIFF
--- a/src/controllers/eventController.ts
+++ b/src/controllers/eventController.ts
@@ -101,7 +101,10 @@ export class eventController {
                             humidity = $(this).text();
                         }
                     });
-                    eventRes.addWeather(air_temp, ground_temp, humidity, track_condition);
+                    
+                    if (Number(esercizio) > 2004) {
+                        eventRes.addWeather(air_temp, ground_temp, humidity, track_condition);
+                    }
 
                     let type;
                     let detail;


### PR DESCRIPTION
They don't have weather data for pre-2015 events, so it was breaking when I tried to view old results from the '60s.

There's probably a smarter way of doing this, but for now this seems to work in dev.